### PR TITLE
Fix figure_name and minor typos in .rst files

### DIFF
--- a/docs/source/pages/how_to_guides.rst
+++ b/docs/source/pages/how_to_guides.rst
@@ -5,7 +5,7 @@ Save figure
 -----------
 To save a **pliffy** plot, we have to specify a minimum of three things in `PliffyInfoABD`:
 
-    - `figure_name`
+    - `plot_name`
     - `save`
     - `save_path`
 
@@ -21,7 +21,7 @@ For example:
     >>> data_b = data[30:]
     >>> info = PliffyInfoABD(data_a=data_a,
                              data_b=data_b,
-                             figure_name='great_figure',
+                             plot_name='great_figure',
                              save=True,
                              save_path='/home/martin/Desktop/'
                              )
@@ -35,7 +35,7 @@ These can easily be changed:
 
     >>> info = PliffyInfoABD(data_a=data_a,
                              data_b=data_b,
-                             figure_name='great_figure',
+                             plot_name='great_figure',
                              save=True,
                              save_path='/home/martin/Desktop/',
                              dpi=300,
@@ -49,7 +49,7 @@ Alternatively, we may want to save our plot to a vector-based format, like `svg`
 
     >>> info_pdf = PliffyInfoABD(data_a=data_a,
                               data_b=data_b,
-                              figure_name='great_figure_pdf',
+                              plot_name='great_figure_pdf',
                               save=True,
                               save_path='/home/martin/Desktop/',
                               save_type='pdf',
@@ -57,7 +57,7 @@ Alternatively, we may want to save our plot to a vector-based format, like `svg`
     >>> plot_abd(info_pdf)
     >>> info_svg = PliffyInfoABD(data_a=data_a,
                               data_b=data_b,
-                              figure_name='great_figure_svg',
+                              plot_name='great_figure_svg',
                               save=True,
                               save_path='/home/martin/Desktop/',
                               save_type='svg',
@@ -127,7 +127,7 @@ If you have added some features to **pliffy**, please add tests that cover the n
 
 All test file are located in the `tests` folder in the root directory of the **pliffy** package.
 
-If your new feature was added to an existing modules, please add your tests to the file named `test_<module_name>.py`. For example, if you added something to the `utils.py` module, your test(s) should go in `test_utils.py`.
+If your new feature was added to an existing module, please add your tests to the file named `test_<module_name>.py`. For example, if you added something to the `utils.py` module, your test(s) should go in `test_utils.py`.
 
 Any new fixtures can be added to the `conftest.py` file.
 
@@ -144,7 +144,7 @@ If your test generates a new figure, please follow the instructions in the `READ
 
 After adding your new test, you will need to run the following command:
 
-.. code-block::
+.. code-block:: python
 
     $ pytest --mpl-generate-path=tests/baseline
 

--- a/docs/source/pages/topic_guides.rst
+++ b/docs/source/pages/topic_guides.rst
@@ -9,7 +9,7 @@ It is hoped that this revised version of **pliffy** can help students and resear
 
 Alternatives to pliffy
 ----------------------
-**pliffy** plots were inspired by the work of `Geoff Cumming`_. Geoff's originally generated his difference plots in Excel with the help of macros, a framework he called ESCI. Since then, his co-author `Robert Calin-Jageman`_ has published this statistical estimation-based framework in R as the `ESCI module`_ for `Jamovi`_.
+**pliffy** plots were inspired by the work of `Geoff Cumming`_. Geoff originally generated his difference plots in Excel with the help of macros, a framework he called ESCI. Since then, his co-author `Robert Calin-Jageman`_ has published this statistical estimation-based framework in R as the `ESCI module`_ for `Jamovi`_.
 
 The other alternative is to **pliffy** is `DABEST-python`_. As stated in the README.md, DABEST stands for Data Analysis using Bootstrap-Coupled ESTimation. It offers a wider variety of difference plots, all based on bootstap estimates.
 

--- a/docs/source/pages/tutorials.rst
+++ b/docs/source/pages/tutorials.rst
@@ -46,7 +46,7 @@ The above figure is the default **pliffy** style. It assumes that `data_a` and `
     diff                    20.26          16.02 to 26.87
     --------------------------------------------------------------
 
-What if our data was paired?
+What if our data were paired?
 
 Part 3. Generate pliffy plot for dependent (paired) observations
 ----------------------------------------------------------------
@@ -63,7 +63,7 @@ First we will create a new version of `data_b` that is dependent or related to `
    :width: 300
    :align: center
 
-Great, but the data actual reflect the distance ants can walk in 30s when they are carrying a piece of paper or a piece of cardboard. Lets add these details to the x-axis and y-axis labels top make our plot more informative. To do this, we will have to import `ABD` from **pliffy**.
+Great, but the data actual reflect the distance ants can walk in 30s when they are carrying a piece of paper or a piece of cardboard. Let's add these details to the x-axis and y-axis labels to make our plot more informative. To do this, we will have to import `ABD` from **pliffy**.
 
 .. code-block:: python
 


### PR DESCRIPTION
I renamed `figure_name` in the docs as `plot_name` to be consistent with `plot_name` argument required in PliffyInfoABD.

I also fixed a code block display, and minor typos. HTML files should be updated. 
